### PR TITLE
Add support for Prompt Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Right now the plugin is limited to these terminal emulators. If one is missing p
 - `konsole`
 - `mate-terminal`
 - `mlterm`
+- `prompt`
 - `qterminal`
 - `rio`
 - `sakura`

--- a/nautilus_open_any_terminal/open_any_terminal_extension.py
+++ b/nautilus_open_any_terminal/open_any_terminal_extension.py
@@ -40,6 +40,7 @@ TERM_WORKDIR_PARAMS = {
     "konsole": None,
     "mate-terminal": None,
     "mlterm": None,
+    "prompt": None,
     "qterminal": None,
     "rio": None,
     "sakura": None,
@@ -55,6 +56,39 @@ TERM_WORKDIR_PARAMS = {
     "xfce4-terminal": None,
     "xterm": None,
     "tabby": ["open"],
+}
+
+NEW_WINDOW_PARAMS = {
+    "alacritty": None,
+    "blackbox": None,
+    "cool-retro-term": None,
+    "deepin-terminal": None,
+    "foot": None,
+    "footclient": None,
+    "gnome-terminal": None,
+    "guake": None,
+    "hyper": None,
+    "kermit": None,
+    "kgx": None,
+    "kitty": None,
+    "konsole": None,
+    "mate-terminal": None,
+    "mlterm": None,
+    "prompt": "--new-window",
+    "qterminal": None,
+    "rio": None,
+    "sakura": None,
+    "st": None,
+    "terminator": None,
+    "terminology": None,
+    "termite": None,
+    "tilix": None,
+    "urxvt": None,
+    "urxvtc": None,
+    "wezterm": None,
+    "xfce4-terminal": None,
+    "xterm": None,
+    "tabby": None,
 }
 
 NEW_TAB_PARAMS = {
@@ -73,6 +107,7 @@ NEW_TAB_PARAMS = {
     "konsole": "--new-tab",
     "mate-terminal": "--tab",
     "mlterm": None,
+    "prompt": "--tab",
     "qterminal": None,
     "rio": None,
     "sakura": None,
@@ -106,6 +141,7 @@ TERM_CMD_PARAMS = {
     "konsole": "-e",
     "mate-terminal": "-e",
     "mlterm": "-e",
+    "prompt": "-x",
     "qterminal": "-e",
     "sakura": "-e",
     "st": "-e",
@@ -138,6 +174,7 @@ TERM_NAME = {
     "konsole": "Konsole",
     "mate-terminal": "Mate Terminal",
     "mlterm": "Mlterm",
+    "prompt": "Prompt",
     "qterminal": "QTerminal",
     "sakura": "Sakura",
     "st": "Simple Terminal",
@@ -158,6 +195,7 @@ FLATPAK_PARMS = ["off", "system", "user"]
 
 FLATPAK_NAMES = {
     "blackbox": "com.raggesilver.BlackBox",
+    "prompt": "org.gnome.Prompt",
     "tilix": "com.gexperts.Tilix",
     "wezterm": "org.wezfurlong.wezterm",
 }
@@ -195,6 +233,8 @@ def open_terminal_in_file(filename):
     cmd = terminal_cmd.copy()
     if new_tab:
         cmd.append(NEW_TAB_PARAMS[terminal])
+    else:
+        cmd.append(NEW_WINDOW_PARAMS[terminal])
 
     cwd_params = TERM_WORKDIR_PARAMS.get(terminal)
     if cwd_params and filename:

--- a/nautilus_open_any_terminal/open_any_terminal_extension.py
+++ b/nautilus_open_any_terminal/open_any_terminal_extension.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # based on: https://github.com/gnunn1/tilix/blob/master/data/nautilus/open-tilix.py
 
+import shlex
 from gettext import gettext, translation
 from os import environ
 from subprocess import Popen
@@ -284,13 +285,16 @@ class OpenAnyTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
         if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
             result = urlparse(file_.get_uri())
             if result.username:
-                value = "ssh -t {0}@{1}".format(result.username, result.hostname)
+                value = "{0}@{1}".format(result.username, result.hostname)
             else:
-                value = "ssh -t {0}".format(result.hostname)
+                value = result.hostname
+            value = "ssh -t " + shlex.quote(value)
             if result.port:
                 value = "{0} -p {1}".format(value, result.port)
             if file_.is_directory():
-                value = '{0} cd "{1}" \\; $SHELL'.format(value, result.path)
+                value = "{0} cd {1} \\; exec \\$SHELL".format(
+                    value, shlex.quote(shlex.quote(unquote(result.path)))
+                )
 
             cmd = terminal_cmd.copy()
             cmd.append(TERM_CMD_PARAMS[terminal])


### PR DESCRIPTION
Adds support for the Prompt terminal (https://gitlab.gnome.org/chergert/prompt)

Allows this PR to close upstream 97 as well.
NEW_WINDOW_PARAMS is required for Prompt due to a quirk where it will focus an existing window instead of opening a new window unless that option is specified.